### PR TITLE
Add getLowerTimestamp() and getHigherTimestamp()

### DIFF
--- a/src/DataValues/TimeValueCalculator.php
+++ b/src/DataValues/TimeValueCalculator.php
@@ -234,7 +234,7 @@ class TimeValueCalculator {
 				1,
 				-$this->charsAffectedByPrecision( TimeValue::PRECISION_YEAR ) - 1
 			);
-			$daysInMonth = cal_days_in_month( CAL_GREGORIAN, $month, $year );
+			$daysInMonth = \cal_days_in_month( CAL_GREGORIAN, $month, $year );
 			$timestampCeiling = substr( $timestamp, 0, -$numCharsToModify ) .
 				$daysInMonth .
 				substr( $this->HIGHEST_TIMESTAMP, -$numCharsToModify + 2 );

--- a/src/DataValues/TimeValueCalculator.php
+++ b/src/DataValues/TimeValueCalculator.php
@@ -62,7 +62,6 @@ class TimeValueCalculator {
 	public function getLowerTimestamp( TimeValue $timeValue ) {
 		$precision = $timeValue->getPrecision();
 		$timestamp = $timeValue->getTime();
-		echo $precision . " | " . $timestamp . " | ";
 		if ( $timestamp[0] === '+' || $precision >= TimeValue::PRECISION_YEAR ) {
 			$timestamp = $this->timestampAbsFloor( $timestamp, $precision );
 		} else {
@@ -81,7 +80,6 @@ class TimeValueCalculator {
 			);
 			$timestamp = $subTimestampLeft . $subTimestampRight;
 		}
-		echo $timestamp . "\n";
 		$unixTimestamp = $this->getSecondsSinceUnixEpoch( $timestamp, $timeValue->getTimezone() );
 		$unixTimestamp -= $timeValue->getBefore() * $this->getSecondsForPrecision( $precision );
 		return $unixTimestamp;
@@ -99,7 +97,6 @@ class TimeValueCalculator {
 	public function getHigherTimestamp( TimeValue $timeValue ) {
 		$precision = $timeValue->getPrecision();
 		$timestamp = $timeValue->getTime();
-		echo 'Timestamp: ' . $timestamp . ' - ';
 		if ( $timestamp[0] === '+' || $precision >= TimeValue::PRECISION_YEAR ) {
 			$timestamp = $this->timestampAbsCeiling( $timestamp, $precision );
 		} else {

--- a/src/DataValues/TimeValueCalculator.php
+++ b/src/DataValues/TimeValueCalculator.php
@@ -164,9 +164,9 @@ class TimeValueCalculator {
 	public function getSecondsForPrecision( $precision ) {
 		if ( $precision <= TimeValue::PRECISION_YEAR ) {
 			return self::SECONDS_PER_GREGORIAN_YEAR * pow(
-					10,
-					TimeValue::PRECISION_YEAR - $precision
-				);
+				10,
+				TimeValue::PRECISION_YEAR - $precision
+			);
 		}
 
 		switch ( $precision ) {

--- a/src/DataValues/TimeValueCalculator.php
+++ b/src/DataValues/TimeValueCalculator.php
@@ -138,7 +138,7 @@ class TimeValueCalculator {
 	 */
 	public function isLeapYear( $year ) {
 		$year = $year < 0 ? ceil( $year ) + 1 : floor( $year );
-		$isMultipleOf4 = fmod( $year, 4 ) === 0.0;
+		$isMultipleOf4   = fmod( $year,   4 ) === 0.0;
 		$isMultipleOf100 = fmod( $year, 100 ) === 0.0;
 		$isMultipleOf400 = fmod( $year, 400 ) === 0.0;
 		return $isMultipleOf4 && !$isMultipleOf100 || $isMultipleOf400;
@@ -171,13 +171,13 @@ class TimeValueCalculator {
 
 		switch ( $precision ) {
 			case TimeValue::PRECISION_SECOND:
-				return 1.0;
+				return 1;
 			case TimeValue::PRECISION_MINUTE:
-				return 60.0;
+				return 60;
 			case TimeValue::PRECISION_HOUR:
-				return 3600.0;
+				return 3600;
 			case TimeValue::PRECISION_DAY:
-				return 86400.0;
+				return 86400;
 			case TimeValue::PRECISION_MONTH:
 				return self::SECONDS_PER_GREGORIAN_YEAR / 12;
 		}

--- a/src/DataValues/TimeValueCalculator.php
+++ b/src/DataValues/TimeValueCalculator.php
@@ -62,7 +62,7 @@ class TimeValueCalculator {
 	public function getLowerTimestamp( TimeValue $timeValue ) {
 		$precision = $timeValue->getPrecision();
 		$timestamp = $timeValue->getTime();
-		if ( strcmp( substr( $timestamp, 0, 1 ), '-' ) === 0 && $precision < TimeValue::PRECISION_YEAR ) {
+		if ( $timestamp[0] === '-' && $precision < TimeValue::PRECISION_YEAR ) {
 			$timestamp = $this->timestampAbsCeiling( $timestamp, $precision );
 		} else {
 			$timestamp = $this->timestampAbsFloor( $timestamp, $precision );

--- a/src/DataValues/TimeValueCalculator.php
+++ b/src/DataValues/TimeValueCalculator.php
@@ -61,14 +61,13 @@ class TimeValueCalculator {
 	public function getLowerTimestamp( TimeValue $timeValue ) {
 		$precision = $timeValue->getPrecision();
 		$timestamp = $timeValue->getTime();
-		if (strcmp(substr($timestamp, 0, 1), '-') === 0 && $precision < TimeValue::PRECISION_YEAR) {
-			$timestamp = $this->timestampAbsCeiling($timestamp, $precision);
+		if ( strcmp( substr( $timestamp, 0, 1 ), '-' ) === 0 && $precision < TimeValue::PRECISION_YEAR ) {
+			$timestamp = $this->timestampAbsCeiling( $timestamp, $precision );
+		} else {
+			$timestamp = $this->timestampAbsFloor( $timestamp, $precision );
 		}
-		else {
-			$timestamp = $this->timestampAbsFloor($timestamp, $precision);
-		}
-		$unixTimestamp = $this->getSecondsSinceUnixEpoch($timestamp, $timeValue->getTimezone());
-		$unixTimestamp -= $timeValue->getBefore() * $this->getSecondsForPrecision($precision);
+		$unixTimestamp = $this->getSecondsSinceUnixEpoch( $timestamp, $timeValue->getTimezone() );
+		$unixTimestamp -= $timeValue->getBefore() * $this->getSecondsForPrecision( $precision );
 		return $unixTimestamp;
 	}
 
@@ -84,14 +83,13 @@ class TimeValueCalculator {
 	public function getHigherTimestamp( TimeValue $timeValue ) {
 		$precision = $timeValue->getPrecision();
 		$timestamp = $timeValue->getTime();
-		if (strcmp(substr($timestamp, 0, 1), '-') === 0 && $precision < TimeValue::PRECISION_YEAR) {
-			$timestamp = $this->timestampAbsFloor($timestamp, $precision);
+		if ( strcmp( substr( $timestamp, 0, 1 ), '-' ) === 0 && $precision < TimeValue::PRECISION_YEAR ) {
+			$timestamp = $this->timestampAbsFloor( $timestamp, $precision );
+		} else {
+			$timestamp = $this->timestampAbsCeiling( $timestamp, $precision );
 		}
-		else {
-			$timestamp = $this->timestampAbsCeiling($timestamp, $precision);
-		}
-		$unixTimestamp = $this->getSecondsSinceUnixEpoch($timestamp, $timeValue->getTimezone());
-		$unixTimestamp += $timeValue->getAfter() * $this->getSecondsForPrecision($precision);
+		$unixTimestamp = $this->getSecondsSinceUnixEpoch( $timestamp, $timeValue->getTimezone() );
+		$unixTimestamp += $timeValue->getAfter() * $this->getSecondsForPrecision( $precision );
 		return $unixTimestamp;
 	}
 
@@ -139,7 +137,7 @@ class TimeValueCalculator {
 	 */
 	public function isLeapYear( $year ) {
 		$year = $year < 0 ? ceil( $year ) + 1 : floor( $year );
-		$isMultipleOf4   = fmod( $year,   4 ) === 0.0;
+		$isMultipleOf4 = fmod( $year, 4 ) === 0.0;
 		$isMultipleOf100 = fmod( $year, 100 ) === 0.0;
 		$isMultipleOf400 = fmod( $year, 400 ) === 0.0;
 		return $isMultipleOf4 && !$isMultipleOf100 || $isMultipleOf400;
@@ -165,9 +163,9 @@ class TimeValueCalculator {
 	public function getSecondsForPrecision( $precision ) {
 		if ( $precision <= TimeValue::PRECISION_YEAR ) {
 			return self::SECONDS_PER_GREGORIAN_YEAR * pow(
-				10,
-				TimeValue::PRECISION_YEAR - $precision
-			);
+					10,
+					TimeValue::PRECISION_YEAR - $precision
+				);
 		}
 
 		switch ( $precision ) {
@@ -189,41 +187,52 @@ class TimeValueCalculator {
 	/**
 	 * @param $timestamp
 	 * @param $precision
+	 *
 	 * @return string
 	 */
-	private function timestampAbsFloor($timestamp, $precision) {
+	private function timestampAbsFloor( $timestamp, $precision ) {
 		// The year is padded with zeros to have 16 digits
-		$timestamp = substr_replace($timestamp,
-			str_repeat('0', self::MAX_LENGTH_TIMESTAMP - strlen($timestamp)), 1, 0);
-		$numCharsToModify = $this->charsAffectedByPrecision($precision);
-		$timestamp = substr($timestamp, 0, -$numCharsToModify) .
-			substr(self::TIMESTAMP_ZERO, -$numCharsToModify);
+		$timestamp = substr_replace(
+			$timestamp,
+			str_repeat( '0', self::MAX_LENGTH_TIMESTAMP - strlen( $timestamp ) ),
+			1,
+			0
+		);
+		$numCharsToModify = $this->charsAffectedByPrecision( $precision );
+		$timestamp = substr( $timestamp, 0, -$numCharsToModify ) .
+			substr( self::TIMESTAMP_ZERO, -$numCharsToModify );
 		return $timestamp;
 	}
 
 	/**
 	 * @param $timestamp
 	 * @param $precision
+	 *
 	 * @return string
 	 */
-	private function timestampAbsCeiling($timestamp, $precision) {
+	private function timestampAbsCeiling( $timestamp, $precision ) {
 		// The year is padded with zeros to have 16 digits
-		$timestamp = substr_replace($timestamp,
-			str_repeat('0', self::MAX_LENGTH_TIMESTAMP - strlen($timestamp)), 1, 0);
-		$numCharsToModify = $this->charsAffectedByPrecision($precision);
+		$timestamp = substr_replace(
+			$timestamp,
+			str_repeat( '0', self::MAX_LENGTH_TIMESTAMP - strlen( $timestamp ) ),
+			1,
+			0
+		);
+		$numCharsToModify = $this->charsAffectedByPrecision( $precision );
 		// WARNING: Day 31 will be applied to all months
-		$timestamp = substr($timestamp, 0, -$numCharsToModify) .
-			substr(self::HIGHEST_TIMESTAMP, -$numCharsToModify);
+		$timestamp = substr( $timestamp, 0, -$numCharsToModify ) .
+			substr( self::HIGHEST_TIMESTAMP, -$numCharsToModify );
 		return $timestamp;
 	}
 
 	/**
 	 * @param $precision
+	 *
 	 * @return int
 	 */
-	private function charsAffectedByPrecision($precision) {
+	private function charsAffectedByPrecision( $precision ) {
 		$numCharsAffected = 1;
-		switch ($precision) {
+		switch ( $precision ) {
 			case TimeValue::PRECISION_MINUTE:
 				$numCharsAffected = 3;
 				break;

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -312,7 +312,9 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 			foreach ( $this->provideTimestampsWithoutSign() as $timestamp ) {
 				$timestamp = $sign . $timestamp;
 				if ( $oldTimestamp !== null ) {
-					yield $sign === '+' ? [ [ $oldTimestamp, $timestamp ] ] : [ [ $timestamp, $oldTimestamp ] ];
+					yield $sign === '+' ?
+						[ [ $oldTimestamp, $timestamp ] ] :
+						[ [ $timestamp, $oldTimestamp ] ];
 				}
 				$oldTimestamp = $timestamp;
 			}
@@ -408,9 +410,9 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSpecificLowerTimestamps() {
 		$timeValuesAndLowerTimestamps = func_get_args();
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		foreach ( $timeValuesAndLowerTimestamps as $timeValueAndLowerTimestamp ) {
-			$unixLowerTimestamp = $timeValueCalculator->getLowerTimestamp( $timeValueAndLowerTimestamp[0] );
+			$unixLowerTimestamp = $calculator->getLowerTimestamp( $timeValueAndLowerTimestamp[0] );
 			$this->assertEquals( $timeValueAndLowerTimestamp[1], $unixLowerTimestamp );
 		}
 	}
@@ -422,9 +424,9 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSpecificHigherTimestamps() {
 		$timeValuesAndHigherTimestamps = func_get_args();
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		foreach ( $timeValuesAndHigherTimestamps as $timeValueAndHigherTimestamp ) {
-			$unixHigherTimestamp = $timeValueCalculator->getHigherTimestamp( $timeValueAndHigherTimestamp[0] );
+			$unixHigherTimestamp = $calculator->getHigherTimestamp( $timeValueAndHigherTimestamp[0] );
 			$this->assertEquals( $timeValueAndHigherTimestamp[2], $unixHigherTimestamp );
 		}
 	}
@@ -436,7 +438,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideTimestampPairs
 	 */
 	public function testOrderingLowerTimestamps() {
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		$timestampPairs = func_get_args();
 		foreach ( $timestampPairs as $timestampPair ) {
 			$earlierTimestamp = $timestampPair[0];
@@ -453,8 +455,8 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 				TimeValue::PRECISION_DAY,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$earlierUnixLowerTimestamp = $timeValueCalculator->getLowerTimestamp( $earlierTimeValue );
-			$laterUnixLowerTimestamp = $timeValueCalculator->getLowerTimestamp( $laterTimeValue );
+			$earlierUnixLowerTimestamp = $calculator->getLowerTimestamp( $earlierTimeValue );
+			$laterUnixLowerTimestamp = $calculator->getLowerTimestamp( $laterTimeValue );
 			$this->assertGreaterThanOrEqual( $earlierUnixLowerTimestamp, $laterUnixLowerTimestamp );
 		}
 	}
@@ -466,7 +468,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideTimestampPairs
 	 */
 	public function testOrderingHigherTimestamps() {
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		$timestampPairs = func_get_args();
 		foreach ( $timestampPairs as $timestampPair ) {
 			$earlierTimestamp = $timestampPair[0];
@@ -483,8 +485,8 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 				TimeValue::PRECISION_DAY,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$earlierUnixHigherTimestamp = $timeValueCalculator->getHigherTimestamp( $earlierTimeValue );
-			$laterUnixHigherTimestamp = $timeValueCalculator->getHigherTimestamp( $laterTimeValue );
+			$earlierUnixHigherTimestamp = $calculator->getHigherTimestamp( $earlierTimeValue );
+			$laterUnixHigherTimestamp = $calculator->getHigherTimestamp( $laterTimeValue );
 			$this->assertGreaterThanOrEqual( $earlierUnixHigherTimestamp, $laterUnixHigherTimestamp );
 		}
 	}
@@ -495,7 +497,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideTimestampsAndPrecisions
 	 */
 	public function testLowerTimestampsVsTimestamps() {
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		$timestampsAndPrecisions = func_get_args();
 		foreach ( $timestampsAndPrecisions as $timestampAndPrecision ) {
 			$timestamp = $timestampAndPrecision[0];
@@ -506,8 +508,8 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 				$precision,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$unixTimestampAsIs = $timeValueCalculator->getTimestamp( $timeValue );
-			$unixLowerTimestamp = $timeValueCalculator->getLowerTimestamp( $timeValue );
+			$unixTimestampAsIs = $calculator->getTimestamp( $timeValue );
+			$unixLowerTimestamp = $calculator->getLowerTimestamp( $timeValue );
 			$this->assertGreaterThanOrEqual( $unixLowerTimestamp, $unixTimestampAsIs );
 		}
 	}
@@ -518,7 +520,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideTimestampsAndPrecisions
 	 */
 	public function testHigherTimestampsVsTimestamps() {
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		$timestampsAndPrecisions = func_get_args();
 		foreach ( $timestampsAndPrecisions as $timestampAndPrecision ) {
 			$timestamp = $timestampAndPrecision[0];
@@ -529,8 +531,8 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 				$precision,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$unixTimestampAsIs = $timeValueCalculator->getTimestamp( $timeValue );
-			$unixHigherTimestamp = $timeValueCalculator->getHigherTimestamp( $timeValue );
+			$unixTimestampAsIs = $calculator->getTimestamp( $timeValue );
+			$unixHigherTimestamp = $calculator->getHigherTimestamp( $timeValue );
 			$this->assertGreaterThanOrEqual( $unixTimestampAsIs, $unixHigherTimestamp );
 		}
 	}
@@ -542,7 +544,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideTimestampsAndPrecisions
 	 */
 	public function testGetLowerTimestampBefore() {
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		$timestampsAndPrecisions = func_get_args();
 		foreach ( $timestampsAndPrecisions as $timestampAndPrecision ) {
 			$timestamp = $timestampAndPrecision[0];
@@ -553,21 +555,21 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 				$precision,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$unixLowerTimestamp = $timeValueCalculator->getLowerTimestamp( $timeValue );
+			$unixLowerTimestamp = $calculator->getLowerTimestamp( $timeValue );
 			$timeValueBefore1 = new TimeValue(
 				$timestamp,
 				0, 1, 1,
 				$precision,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$unixLowerTimestampBefore1 = $timeValueCalculator->getLowerTimestamp( $timeValueBefore1 );
+			$unixLowerTimestampBefore1 = $calculator->getLowerTimestamp( $timeValueBefore1 );
 			$timeValueBefore2 = new TimeValue(
 				$timestamp,
 				0, 2, 0,
 				$precision,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$unixLowerTimestampBefore2 = $timeValueCalculator->getLowerTimestamp( $timeValueBefore2 );
+			$unixLowerTimestampBefore2 = $calculator->getLowerTimestamp( $timeValueBefore2 );
 			if ( $unixLowerTimestamp > -10000000000000 && $unixLowerTimestamp < 10000000000000 ) {
 				$this->assertGreaterThan( $unixLowerTimestampBefore1, $unixLowerTimestamp );
 				$this->assertGreaterThan( $unixLowerTimestampBefore2, $unixLowerTimestampBefore1 );
@@ -585,7 +587,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideTimestampsAndPrecisions
 	 */
 	public function testGetHigherTimestampAfter() {
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		$timestampsAndPrecisions = func_get_args();
 		foreach ( $timestampsAndPrecisions as $timestampAndPrecision ) {
 			$timestamp = $timestampAndPrecision[0];
@@ -596,21 +598,21 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 				$precision,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$unixHigherTimestamp = $timeValueCalculator->getHigherTimestamp( $timeValue );
+			$unixHigherTimestamp = $calculator->getHigherTimestamp( $timeValue );
 			$timeValueAfter1 = new TimeValue(
 				$timestamp,
 				0, 1, 1,
 				$precision,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$unixHigherTimestampAfter1 = $timeValueCalculator->getHigherTimestamp( $timeValueAfter1 );
+			$unixHigherTimestampAfter1 = $calculator->getHigherTimestamp( $timeValueAfter1 );
 			$timeValueAfter2 = new TimeValue(
 				$timestamp,
 				0, 0, 2,
 				$precision,
 				TimeValue::CALENDAR_GREGORIAN
 			);
-			$unixHigherTimestampAfter2 = $timeValueCalculator->getHigherTimestamp( $timeValueAfter2 );
+			$unixHigherTimestampAfter2 = $calculator->getHigherTimestamp( $timeValueAfter2 );
 			if ( $unixHigherTimestamp > -10000000000000 && $unixHigherTimestamp < 10000000000000 ) {
 				$this->assertGreaterThan( $unixHigherTimestamp, $unixHigherTimestampAfter1 );
 				$this->assertGreaterThan( $unixHigherTimestampAfter1, $unixHigherTimestampAfter2 );
@@ -628,11 +630,11 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideTimeValuesHighVsLowPrecisions
 	 */
 	public function testGetLowerTimestampsHighVsLowPrecisions() {
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		$timeValuesHighVsLowPrecisions = func_get_args();
 		foreach ( $timeValuesHighVsLowPrecisions as $timeValueHighVsLowPrecision ) {
-			$timestampHighPrecision = $timeValueCalculator->getLowerTimestamp( $timeValueHighVsLowPrecision[0] );
-			$timestampLowPrecision = $timeValueCalculator->getLowerTimestamp( $timeValueHighVsLowPrecision[1] );
+			$timestampHighPrecision = $calculator->getLowerTimestamp( $timeValueHighVsLowPrecision[0] );
+			$timestampLowPrecision = $calculator->getLowerTimestamp( $timeValueHighVsLowPrecision[1] );
 			$this->assertGreaterThanOrEqual( $timestampLowPrecision, $timestampHighPrecision );
 		}
 	}
@@ -644,11 +646,11 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider provideTimeValuesHighVsLowPrecisions
 	 */
 	public function testGetHigherTimestampsHighVsLowPrecisions() {
-		$timeValueCalculator = new TimeValueCalculator();
+		$calculator = new TimeValueCalculator();
 		$timeValuesHighVsLowPrecisions = func_get_args();
 		foreach ( $timeValuesHighVsLowPrecisions as $timeValueHighVsLowPrecision ) {
-			$timestampHighPrecision = $timeValueCalculator->getHigherTimestamp( $timeValueHighVsLowPrecision[0] );
-			$timestampLowPrecision = $timeValueCalculator->getHigherTimestamp( $timeValueHighVsLowPrecision[1] );
+			$timestampHighPrecision = $calculator->getHigherTimestamp( $timeValueHighVsLowPrecision[0] );
+			$timestampLowPrecision = $calculator->getHigherTimestamp( $timeValueHighVsLowPrecision[1] );
 			$this->assertGreaterThanOrEqual( $timestampHighPrecision, $timestampLowPrecision );
 		}
 	}

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -269,7 +269,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	private function auxTestGetLowerTimestamp($timestamp) {
 		$timeValueCalculator = new TimeValueCalculator();
-		$array = precisionProvider();
+		$array = simplePrecisionProvider();
 		foreach ($array as &$precision) {
 			$timeValue = new TimeValue($timestamp,
 				0, 0, 0,
@@ -300,7 +300,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	private function auxTestGetHigherTimestamp($timestamp) {
 		$timeValueCalculator = new TimeValueCalculator();
-		$array = precisionProvider();
+		$array = simplePrecisionProvider();
 		foreach ($array as &$precision) {
 			$timeValue = new TimeValue($timestamp,
 				0, 0, 0,

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -253,8 +253,8 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 		$precisions = $this->simplePrecisionProvider();
 		foreach ( $timestamps as &$timestamp ) {
 			foreach ( $precisions as &$precision ) {
-				$this->auxTestGetLowerTimestamp( '+' . $timestamp );
-				$this->auxTestGetLowerTimestamp( '-' . $timestamp );
+				$this->auxTestGetLowerTimestamp( '+' . $timestamp, $precision );
+				$this->auxTestGetLowerTimestamp( '-' . $timestamp, $precision );
 			}
 		}
 		$timeValue = new TimeValue(

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -255,7 +255,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @return \Generator
 	 */
-	public function provideTimestamps() { // any order
+	public function provideTimestamps() {
 		foreach ( [ '+', '-' ] as $sign ) {
 			foreach ( $this->provideTimestampsWithoutSign() as $timestamp ) {
 				yield $sign . $timestamp;

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -208,5 +208,122 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals( $expected, $seconds );
 	}
+	
+	/**
+	 * @return array
+	 */
+	private function timestampWithoutSignProvider() {
+		return array(
+			'1054-02-11' . 'T' . '14:00:02' . 'Z',
+			'16-11-11' . 'T' . '06:08:04' . 'Z',
+			'2012-02-29' . 'T' . '23:59:59' . 'Z',
+			'2012-03-01' . 'T' . '00:00:00' . 'Z',
+			'2013-02-29' . 'T' . '23:59:59' . 'Z',
+			'2013-03-01' . 'T' . '00:00:00' . 'Z',
+			'99999-12-31' . 'T' . '23:59:59' . 'Z',
+			'0001-01-01' . 'T' . '00:00:00' . 'Z',
+		);
+	}
+
+	/**
+	 * @return array
+	 */
+	private function simplePrecisionProvider() {
+		return array(
+			TimeValue::PRECISION_SECOND,
+			TimeValue::PRECISION_MINUTE,
+			TimeValue::PRECISION_HOUR,
+			TimeValue::PRECISION_DAY,
+			TimeValue::PRECISION_MONTH,
+			TimeValue::PRECISION_YEAR,
+			TimeValue::PRECISION_YEAR10,
+			TimeValue::PRECISION_YEAR100,
+			TimeValue::PRECISION_YEAR1K,
+			TimeValue::PRECISION_YEAR10K,
+			TimeValue::PRECISION_YEAR100K,
+			TimeValue::PRECISION_YEAR1M,
+			TimeValue::PRECISION_YEAR10M,
+			TimeValue::PRECISION_YEAR100M,
+			TimeValue::PRECISION_YEAR1G
+		);
+	}
+
+	public function testGetLowerTimestamp() {
+		$timestamps = $this->timestampWithoutSignProvider();
+		foreach ($timestamps as &$timestamp) {
+			$this->auxTestGetLowerTimestamp('+' . $timestamp);
+			$this->auxTestGetLowerTimestamp('-' . $timestamp);
+		}
+	}
+
+	public function testGetHigherTimestamp() {
+		$timestamps = $this->timestampWithoutSignProvider();
+		foreach ($timestamps as &$timestamp) {
+			$this->auxTestGetHigherTimestamp('+' . $timestamp);
+			$this->auxTestGetHigherTimestamp('-' . $timestamp);
+		}
+	}
+
+	/**
+	 * @param $timestamp
+	 */
+	private function auxTestGetLowerTimestamp($timestamp) {
+		$timeValueCalculator = new TimeValueCalculator();
+		$array = precisionProvider();
+		foreach ($array as &$precision) {
+			$timeValue = new TimeValue($timestamp,
+				0, 0, 0,
+				$precision,
+				TimeValue::CALENDAR_GREGORIAN);
+			$unixTimestampAsIs = $timeValueCalculator->getTimestamp($timeValue);
+			$unixLowerTimestamp = $timeValueCalculator->getLowerTimestamp($timeValue);
+			$this->assertGreaterThanOrEqual($unixLowerTimestamp, $unixTimestampAsIs);
+
+			$timeValueBefore1 = new TimeValue($timestamp,
+				0, 1, 1,
+				$precision,
+				TimeValue::CALENDAR_GREGORIAN);
+			$unixLowerTimestampBefore1 = $timeValueCalculator->getLowerTimestamp($timeValueBefore1);
+			$this->assertGreaterThan($unixLowerTimestampBefore1, $unixLowerTimestamp);
+
+			$timeValueBefore2 = new TimeValue($timestamp,
+				0, 2, 2,
+				$precision,
+				TimeValue::CALENDAR_GREGORIAN);
+			$unixLowerTimestampBefore2 = $timeValueCalculator->getLowerTimestamp($timeValueBefore2);
+			$this->assertGreaterThan($unixLowerTimestampBefore2, $unixLowerTimestampBefore1);
+		}
+	}
+
+	/**
+	 * @param $timestamp
+	 */
+	private function auxTestGetHigherTimestamp($timestamp) {
+		$timeValueCalculator = new TimeValueCalculator();
+		$array = precisionProvider();
+		foreach ($array as &$precision) {
+			$timeValue = new TimeValue($timestamp,
+				0, 0, 0,
+				$precision,
+				TimeValue::CALENDAR_GREGORIAN);
+			$unixTimestampAsIs = $timeValueCalculator->getTimestamp($timeValue);
+			$unixHigherTimestamp = $timeValueCalculator->getHigherTimestamp($timeValue);
+			$this->assertLessThanOrEqual($unixHigherTimestamp, $unixTimestampAsIs);
+
+			$timeValueAfter1 = new TimeValue($timestamp,
+				0, 1, 1,
+				$precision,
+				TimeValue::CALENDAR_GREGORIAN);
+			$unixHigherTimestampAfter1 = $timeValueCalculator->getHigherTimestamp($timeValueAfter1);
+			$this->assertLessThan($unixHigherTimestampAfter1, $unixHigherTimestamp);
+
+			$timeValueAfter2 = new TimeValue($timestamp,
+				0, 2, 2,
+				$precision,
+				TimeValue::CALENDAR_GREGORIAN);
+			$unixHigherTimestampAfter2 = $timeValueCalculator->getHigherTimestamp($timeValueAfter2);
+			$this->assertLessThan($unixHigherTimestampAfter2, $unixHigherTimestampAfter1);
+		}
+	}
 
 }

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -208,12 +208,12 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals( $expected, $seconds );
 	}
-	
+
 	/**
 	 * @return array
 	 */
 	private function timestampWithoutSignProvider() {
-		return array(
+		return [
 			'1054-02-11' . 'T' . '14:00:02' . 'Z',
 			'16-11-11' . 'T' . '06:08:04' . 'Z',
 			'2012-02-29' . 'T' . '23:59:59' . 'Z',
@@ -222,14 +222,14 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 			'2013-03-01' . 'T' . '00:00:00' . 'Z',
 			'99999-12-31' . 'T' . '23:59:59' . 'Z',
 			'0001-01-01' . 'T' . '00:00:00' . 'Z',
-		);
+		];
 	}
 
 	/**
 	 * @return array
 	 */
 	private function simplePrecisionProvider() {
-		return array(
+		return [
 			TimeValue::PRECISION_SECOND,
 			TimeValue::PRECISION_MINUTE,
 			TimeValue::PRECISION_HOUR,
@@ -245,84 +245,96 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 			TimeValue::PRECISION_YEAR10M,
 			TimeValue::PRECISION_YEAR100M,
 			TimeValue::PRECISION_YEAR1G
-		);
+		];
 	}
 
 	public function testGetLowerTimestamp() {
 		$timestamps = $this->timestampWithoutSignProvider();
-		foreach ($timestamps as &$timestamp) {
-			$this->auxTestGetLowerTimestamp('+' . $timestamp);
-			$this->auxTestGetLowerTimestamp('-' . $timestamp);
+		foreach ( $timestamps as &$timestamp ) {
+			$this->auxTestGetLowerTimestamp( '+' . $timestamp );
+			$this->auxTestGetLowerTimestamp( '-' . $timestamp );
 		}
 	}
 
 	public function testGetHigherTimestamp() {
 		$timestamps = $this->timestampWithoutSignProvider();
-		foreach ($timestamps as &$timestamp) {
-			$this->auxTestGetHigherTimestamp('+' . $timestamp);
-			$this->auxTestGetHigherTimestamp('-' . $timestamp);
+		foreach ( $timestamps as &$timestamp ) {
+			$this->auxTestGetHigherTimestamp( '+' . $timestamp );
+			$this->auxTestGetHigherTimestamp( '-' . $timestamp );
 		}
 	}
 
 	/**
 	 * @param $timestamp
 	 */
-	private function auxTestGetLowerTimestamp($timestamp) {
+	private function auxTestGetLowerTimestamp( $timestamp ) {
 		$timeValueCalculator = new TimeValueCalculator();
 		$array = $this->simplePrecisionProvider();
-		foreach ($array as &$precision) {
-			$timeValue = new TimeValue($timestamp,
+		foreach ( $array as &$precision ) {
+			$timeValue = new TimeValue(
+				$timestamp,
 				0, 0, 0,
 				$precision,
-				TimeValue::CALENDAR_GREGORIAN);
-			$unixTimestampAsIs = $timeValueCalculator->getTimestamp($timeValue);
-			$unixLowerTimestamp = $timeValueCalculator->getLowerTimestamp($timeValue);
-			$this->assertGreaterThanOrEqual($unixLowerTimestamp, $unixTimestampAsIs);
+				TimeValue::CALENDAR_GREGORIAN
+			);
+			$unixTimestampAsIs = $timeValueCalculator->getTimestamp( $timeValue );
+			$unixLowerTimestamp = $timeValueCalculator->getLowerTimestamp( $timeValue );
+			$this->assertGreaterThanOrEqual( $unixLowerTimestamp, $unixTimestampAsIs );
 
-			$timeValueBefore1 = new TimeValue($timestamp,
+			$timeValueBefore1 = new TimeValue(
+				$timestamp,
 				0, 1, 1,
 				$precision,
-				TimeValue::CALENDAR_GREGORIAN);
-			$unixLowerTimestampBefore1 = $timeValueCalculator->getLowerTimestamp($timeValueBefore1);
-			$this->assertGreaterThan($unixLowerTimestampBefore1, $unixLowerTimestamp);
+				TimeValue::CALENDAR_GREGORIAN
+			);
+			$unixLowerTimestampBefore1 = $timeValueCalculator->getLowerTimestamp( $timeValueBefore1 );
+			$this->assertGreaterThan( $unixLowerTimestampBefore1, $unixLowerTimestamp );
 
-			$timeValueBefore2 = new TimeValue($timestamp,
+			$timeValueBefore2 = new TimeValue(
+				$timestamp,
 				0, 2, 2,
 				$precision,
-				TimeValue::CALENDAR_GREGORIAN);
-			$unixLowerTimestampBefore2 = $timeValueCalculator->getLowerTimestamp($timeValueBefore2);
-			$this->assertGreaterThan($unixLowerTimestampBefore2, $unixLowerTimestampBefore1);
+				TimeValue::CALENDAR_GREGORIAN
+			);
+			$unixLowerTimestampBefore2 = $timeValueCalculator->getLowerTimestamp( $timeValueBefore2 );
+			$this->assertGreaterThan( $unixLowerTimestampBefore2, $unixLowerTimestampBefore1 );
 		}
 	}
 
 	/**
 	 * @param $timestamp
 	 */
-	private function auxTestGetHigherTimestamp($timestamp) {
+	private function auxTestGetHigherTimestamp( $timestamp ) {
 		$timeValueCalculator = new TimeValueCalculator();
 		$array = $this->simplePrecisionProvider();
-		foreach ($array as &$precision) {
-			$timeValue = new TimeValue($timestamp,
+		foreach ( $array as &$precision ) {
+			$timeValue = new TimeValue(
+				$timestamp,
 				0, 0, 0,
 				$precision,
-				TimeValue::CALENDAR_GREGORIAN);
-			$unixTimestampAsIs = $timeValueCalculator->getTimestamp($timeValue);
-			$unixHigherTimestamp = $timeValueCalculator->getHigherTimestamp($timeValue);
-			$this->assertLessThanOrEqual($unixHigherTimestamp, $unixTimestampAsIs);
+				TimeValue::CALENDAR_GREGORIAN
+			);
+			$unixTimestampAsIs = $timeValueCalculator->getTimestamp( $timeValue );
+			$unixHigherTimestamp = $timeValueCalculator->getHigherTimestamp( $timeValue );
+			$this->assertLessThanOrEqual( $unixHigherTimestamp, $unixTimestampAsIs );
 
-			$timeValueAfter1 = new TimeValue($timestamp,
+			$timeValueAfter1 = new TimeValue(
+				$timestamp,
 				0, 1, 1,
 				$precision,
-				TimeValue::CALENDAR_GREGORIAN);
-			$unixHigherTimestampAfter1 = $timeValueCalculator->getHigherTimestamp($timeValueAfter1);
-			$this->assertLessThan($unixHigherTimestampAfter1, $unixHigherTimestamp);
+				TimeValue::CALENDAR_GREGORIAN
+			);
+			$unixHigherTimestampAfter1 = $timeValueCalculator->getHigherTimestamp( $timeValueAfter1 );
+			$this->assertLessThan( $unixHigherTimestampAfter1, $unixHigherTimestamp );
 
-			$timeValueAfter2 = new TimeValue($timestamp,
+			$timeValueAfter2 = new TimeValue(
+				$timestamp,
 				0, 2, 2,
 				$precision,
-				TimeValue::CALENDAR_GREGORIAN);
-			$unixHigherTimestampAfter2 = $timeValueCalculator->getHigherTimestamp($timeValueAfter2);
-			$this->assertLessThan($unixHigherTimestampAfter2, $unixHigherTimestampAfter1);
+				TimeValue::CALENDAR_GREGORIAN
+			);
+			$unixHigherTimestampAfter2 = $timeValueCalculator->getHigherTimestamp( $timeValueAfter2 );
+			$this->assertLessThan( $unixHigherTimestampAfter2, $unixHigherTimestampAfter1 );
 		}
 	}
 

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -214,6 +214,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	private function timestampWithoutSignProvider() {
 		return [
+			'1-06-16T11:45:12Z',
 			'16-11-11T06:08:04Z',
 			'245-04-30T00:00:00Z',
 			'1054-02-11T14:00:02Z',
@@ -433,7 +434,6 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 					// As $precisions are ordered from most to least precise, old higher timestamps must be
 					// less than or equal to current higher timestamps
 					if ( !empty( $oldUnixHigherTimestamp ) ) {
-						echo $oldUnixHigherTimestamp . ' < ' . $unixHigherTimestamp . "\n";
 						$this->assertLessThanOrEqual( $unixHigherTimestamp, $oldUnixHigherTimestamp );
 					}
 					$oldUnixHigherTimestamp = $unixHigherTimestamp;

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -218,9 +218,9 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 			'16-11-11' . 'T' . '06:08:04' . 'Z',
 			'2012-02-29' . 'T' . '23:59:59' . 'Z',
 			'2012-03-01' . 'T' . '00:00:00' . 'Z',
-			'2013-02-29' . 'T' . '23:59:59' . 'Z',
-			'2013-03-01' . 'T' . '00:00:00' . 'Z',
-			'99999-12-31' . 'T' . '23:59:59' . 'Z',
+			'2013-02-28' . 'T' . '23:59:59' . 'Z',
+			'2013-03-01' . 'T' . '00:07:00' . 'Z',
+			'9999999-12-31' . 'T' . '23:59:59' . 'Z',
 			'0001-01-01' . 'T' . '00:00:00' . 'Z',
 		];
 	}
@@ -250,92 +250,112 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetLowerTimestamp() {
 		$timestamps = $this->timestampWithoutSignProvider();
+		$precisions = $this->simplePrecisionProvider();
 		foreach ( $timestamps as &$timestamp ) {
-			$this->auxTestGetLowerTimestamp( '+' . $timestamp );
-			$this->auxTestGetLowerTimestamp( '-' . $timestamp );
+			foreach ( $precisions as &$precision ) {
+				$this->auxTestGetLowerTimestamp( '+' . $timestamp );
+				$this->auxTestGetLowerTimestamp( '-' . $timestamp );
+			}
 		}
+		$timeValue = new TimeValue(
+			'+' . '2013-03-14' . 'T' . '12:51:02' . 'Z',
+			0, 0, 0,
+			TimeValue::PRECISION_MONTH,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+		$timeValueCalculator = new TimeValueCalculator();
+		$timestampValue = $timeValueCalculator->getLowerTimestamp( $timeValue );
+		$this->assertEquals( 1362096000, $timestampValue );
 	}
 
 	public function testGetHigherTimestamp() {
 		$timestamps = $this->timestampWithoutSignProvider();
+		$precisions = $this->simplePrecisionProvider();
 		foreach ( $timestamps as &$timestamp ) {
-			$this->auxTestGetHigherTimestamp( '+' . $timestamp );
-			$this->auxTestGetHigherTimestamp( '-' . $timestamp );
+			foreach ( $precisions as &$precision ) {
+				$this->auxTestGetHigherTimestamp( '+' . $timestamp, $precision );
+				$this->auxTestGetHigherTimestamp( '-' . $timestamp, $precision );
+			}
 		}
+		$timeValue = new TimeValue(
+			'+' . '2013-02-14' . 'T' . '12:51:02' . 'Z',
+			0, 0, 0,
+			TimeValue::PRECISION_MONTH,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+		$timeValueCalculator = new TimeValueCalculator();
+		$timestampValue = $timeValueCalculator->getHigherTimestamp( $timeValue );
+		$this->assertEquals( 1362095999, $timestampValue );
 	}
 
 	/**
-	 * @param $timestamp
+	 * @param string $timestamp
+	 * @param int $precision
 	 */
-	private function auxTestGetLowerTimestamp( $timestamp ) {
+	private function auxTestGetLowerTimestamp( $timestamp, $precision ) {
 		$timeValueCalculator = new TimeValueCalculator();
-		$array = $this->simplePrecisionProvider();
-		foreach ( $array as &$precision ) {
-			$timeValue = new TimeValue(
-				$timestamp,
-				0, 0, 0,
-				$precision,
-				TimeValue::CALENDAR_GREGORIAN
-			);
-			$unixTimestampAsIs = $timeValueCalculator->getTimestamp( $timeValue );
-			$unixLowerTimestamp = $timeValueCalculator->getLowerTimestamp( $timeValue );
-			$this->assertGreaterThanOrEqual( $unixLowerTimestamp, $unixTimestampAsIs );
+		$timeValue = new TimeValue(
+			$timestamp,
+			0, 0, 0,
+			$precision,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+		$unixTimestampAsIs = $timeValueCalculator->getTimestamp( $timeValue );
+		$unixLowerTimestamp = $timeValueCalculator->getLowerTimestamp( $timeValue );
+		$this->assertGreaterThanOrEqual( $unixLowerTimestamp, $unixTimestampAsIs );
 
-			$timeValueBefore1 = new TimeValue(
-				$timestamp,
-				0, 1, 1,
-				$precision,
-				TimeValue::CALENDAR_GREGORIAN
-			);
-			$unixLowerTimestampBefore1 = $timeValueCalculator->getLowerTimestamp( $timeValueBefore1 );
-			$this->assertGreaterThan( $unixLowerTimestampBefore1, $unixLowerTimestamp );
+		$timeValueBefore1 = new TimeValue(
+			$timestamp,
+			0, 1, 1,
+			$precision,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+		$unixLowerTimestampBefore1 = $timeValueCalculator->getLowerTimestamp( $timeValueBefore1 );
+		$this->assertGreaterThan( $unixLowerTimestampBefore1, $unixLowerTimestamp );
 
-			$timeValueBefore2 = new TimeValue(
-				$timestamp,
-				0, 2, 2,
-				$precision,
-				TimeValue::CALENDAR_GREGORIAN
-			);
-			$unixLowerTimestampBefore2 = $timeValueCalculator->getLowerTimestamp( $timeValueBefore2 );
-			$this->assertGreaterThan( $unixLowerTimestampBefore2, $unixLowerTimestampBefore1 );
-		}
+		$timeValueBefore2 = new TimeValue(
+			$timestamp,
+			0, 2, 2,
+			$precision,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+		$unixLowerTimestampBefore2 = $timeValueCalculator->getLowerTimestamp( $timeValueBefore2 );
+		$this->assertGreaterThan( $unixLowerTimestampBefore2, $unixLowerTimestampBefore1 );
 	}
 
 	/**
-	 * @param $timestamp
+	 * @param string $timestamp
+	 * @param int $precision
 	 */
-	private function auxTestGetHigherTimestamp( $timestamp ) {
+	private function auxTestGetHigherTimestamp( $timestamp, $precision ) {
 		$timeValueCalculator = new TimeValueCalculator();
-		$array = $this->simplePrecisionProvider();
-		foreach ( $array as &$precision ) {
-			$timeValue = new TimeValue(
-				$timestamp,
-				0, 0, 0,
-				$precision,
-				TimeValue::CALENDAR_GREGORIAN
-			);
-			$unixTimestampAsIs = $timeValueCalculator->getTimestamp( $timeValue );
-			$unixHigherTimestamp = $timeValueCalculator->getHigherTimestamp( $timeValue );
-			$this->assertLessThanOrEqual( $unixHigherTimestamp, $unixTimestampAsIs );
+		$timeValue = new TimeValue(
+			$timestamp,
+			0, 0, 0,
+			$precision,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+		$unixTimestampAsIs = $timeValueCalculator->getTimestamp( $timeValue );
+		$unixHigherTimestamp = $timeValueCalculator->getHigherTimestamp( $timeValue );
+		$this->assertLessThanOrEqual( $unixHigherTimestamp, $unixTimestampAsIs );
 
-			$timeValueAfter1 = new TimeValue(
-				$timestamp,
-				0, 1, 1,
-				$precision,
-				TimeValue::CALENDAR_GREGORIAN
-			);
-			$unixHigherTimestampAfter1 = $timeValueCalculator->getHigherTimestamp( $timeValueAfter1 );
-			$this->assertLessThan( $unixHigherTimestampAfter1, $unixHigherTimestamp );
+		$timeValueAfter1 = new TimeValue(
+			$timestamp,
+			0, 1, 1,
+			$precision,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+		$unixHigherTimestampAfter1 = $timeValueCalculator->getHigherTimestamp( $timeValueAfter1 );
+		$this->assertLessThan( $unixHigherTimestampAfter1, $unixHigherTimestamp );
 
-			$timeValueAfter2 = new TimeValue(
-				$timestamp,
-				0, 2, 2,
-				$precision,
-				TimeValue::CALENDAR_GREGORIAN
-			);
-			$unixHigherTimestampAfter2 = $timeValueCalculator->getHigherTimestamp( $timeValueAfter2 );
-			$this->assertLessThan( $unixHigherTimestampAfter2, $unixHigherTimestampAfter1 );
-		}
+		$timeValueAfter2 = new TimeValue(
+			$timestamp,
+			0, 2, 2,
+			$precision,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+		$unixHigherTimestampAfter2 = $timeValueCalculator->getHigherTimestamp( $timeValueAfter2 );
+		$this->assertLessThan( $unixHigherTimestampAfter2, $unixHigherTimestampAfter1 );
 	}
 
 }

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -269,7 +269,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	private function auxTestGetLowerTimestamp($timestamp) {
 		$timeValueCalculator = new TimeValueCalculator();
-		$array = simplePrecisionProvider();
+		$array = $this->simplePrecisionProvider();
 		foreach ($array as &$precision) {
 			$timeValue = new TimeValue($timestamp,
 				0, 0, 0,
@@ -300,7 +300,7 @@ class TimeValueCalculatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	private function auxTestGetHigherTimestamp($timestamp) {
 		$timeValueCalculator = new TimeValueCalculator();
-		$array = simplePrecisionProvider();
+		$array = $this->simplePrecisionProvider();
 		foreach ($array as &$precision) {
 			$timeValue = new TimeValue($timestamp,
 				0, 0, 0,


### PR DESCRIPTION
Add public functions getLowerTimestamp() and getHigherTimestamp() together with their tests and private functions. They will be used in WikibaseQualityConstraints to fix <https://phabricator.wikimedia.org/T195226>.