### PR TITLE
Refresh PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 language: php
 
-dist: trusty
+dist: bionic
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
-  - hhvm-3.18
+  - 7.3
 
 install: travis_retry composer install
 
 script: composer test
 
 after_success:
-  - if [[ "`phpenv version-name`" != "7.1" ]]; then exit 0; fi
+  - if [[ "`phpenv version-name`" != "7.3" ]]; then exit 0; fi
   - vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.5.9",
+		"php": ">=7.2.0",
 		"data-values/data-values": "~2.0|~1.0|~0.1",
 		"data-values/interfaces": "~0.2.0",
 		"data-values/common": "~0.4.0|~0.3.0"


### PR DESCRIPTION
All of the removed versions (other than HHVM, I suppose) are EOLed already, so I don’t think we need to consider this a breaking change.

7.3 is added, but 7.4 isn’t added yet, because it currently fails in Travis CI because some of our used packages are so old. I’ll fix that separately.