### PR TITLE
Update PhpDateTimeParser for PHP 8.1.7+

### DIFF
--- a/src/ValueParsers/PhpDateTimeParser.php
+++ b/src/ValueParsers/PhpDateTimeParser.php
@@ -144,7 +144,9 @@ class PhpDateTimeParser extends StringValueParser {
 	 * @return string
 	 */
 	private function getValueWithFixedSeparators( $value, $year = null ) {
-		$isYmd = $year !== null && preg_match( '/^\D*' . $year . '\D+\d+\D+\d+\D*$/', $value );
+		// Since PHP 8.1.7 YYYY-DDD means the DDDth day of the year, thus only add dashes
+		// if we have up to two digits in the second field.
+		$isYmd = $year !== null && preg_match( '/^\D*' . $year . '\D+\d{1,2}\D+\d+\D*$/', $value );
 		$separator = $isYmd ? '-' : '.';
 		// Meant to match separator characters after day and month. \p{L} matches letters outside
 		// the ASCII range.

--- a/tests/ValueParsers/PhpDateTimeParserTest.php
+++ b/tests/ValueParsers/PhpDateTimeParserTest.php
@@ -241,6 +241,12 @@ class PhpDateTimeParserTest extends ValueParserTestCase {
 				array( '+1991-01-01T00:00:00Z' ),
 		);
 
+		// Only supported from PHP 8.1.7 (https://bugs.php.net/bug.php?id=51987, included in PHP 8.1.7)
+		if ( version_compare( PHP_VERSION, '8.1.7', '>=' ) ) {
+			// YYYY-DDD (DDDth day of the year)
+			$valid['2022-033'] = array( '+0000000000002022-02-02T00:00:00Z', TimeValue::PRECISION_DAY, $gregorian );
+		}
+
 		foreach ( $valid as $value => $args ) {
 			$timestamp = $args[0];
 			$precision = isset( $args[1] ) ? $args[1] : TimeValue::PRECISION_DAY;


### PR DESCRIPTION
Starting from PHP 8.1.7 `DateTime` interprets `YYYY-DDD` as the DDDth day of the year.

We need to take this into account (to not accidentally mangle input into that format).

See also:
- https://bugs.php.net/bug.php?id=51987
- https://www.php.net/ChangeLog-8.php#8.1.7