### PR TITLE
Add PHP 8.1 to CI, update mediawiki/mediawiki-codesniffer to ^39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.3
   - 7.4
   - 8.0
+  - 8.1
 
 install: travis_retry composer install
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~8.5",
-		"mediawiki/mediawiki-codesniffer": "^38"
+		"mediawiki/mediawiki-codesniffer": "^39"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~8.5",
-		"mediawiki/mediawiki-codesniffer": "34.0.0"
+		"mediawiki/mediawiki-codesniffer": "^38"
 	},
 	"autoload": {
 		"psr-0": {

--- a/src/ValueParsers/MonthNameUnlocalizer.php
+++ b/src/ValueParsers/MonthNameUnlocalizer.php
@@ -26,7 +26,7 @@ class MonthNameUnlocalizer {
 		$this->replacements = $replacements;
 
 		// Order search strings from longest to shortest
-		uksort( $this->replacements, function ( $a, $b ) {
+		uksort( $this->replacements, static function ( $a, $b ) {
 			return strlen( $b ) - strlen( $a );
 		} );
 	}

--- a/src/ValueParsers/YearMonthTimeParser.php
+++ b/src/ValueParsers/YearMonthTimeParser.php
@@ -65,14 +65,7 @@ class YearMonthTimeParser extends StringValueParser {
 	 */
 	protected function stringParse( $value ) {
 		list( $newValue, $sign ) = $this->splitBySignAndEra( $value );
-
-		// Matches year and month separated by a separator.
-		// \p{L} matches letters outside the ASCII range.
-		$regex = '/^(-?[\d\p{L}]+)\s*?[\/\-\s.,]\s*(-?[\d\p{L}]+)$/u';
-		if ( !preg_match( $regex, $newValue, $matches ) ) {
-			throw new ParseException( 'Failed to parse year and month', $value, self::FORMAT_NAME );
-		}
-		list( , $a, $b ) = $matches;
+		list( $a, $b ) = $this->splitByYearMonth( $value, $newValue );
 
 		// non-empty sign indicates the era (e.g. "BCE") was specified
 		// don't accept a negative number as the year
@@ -105,6 +98,24 @@ class YearMonthTimeParser extends StringValueParser {
 		}
 
 		throw new ParseException( 'Failed to parse year and month', $value, self::FORMAT_NAME );
+	}
+
+	/**
+	 * Returns two strings which can either be the month or year (depending on input order)
+	 *
+	 * @param string $originalValue The value as original given (for error reporting)
+	 * @param string $newValue As produced by splitBySignAndEra
+	 *
+	 * @return array( string $a, string $b )
+	 */
+	private function splitByYearMonth( $originalValue, string $newValue ): array {
+		// Matches year and month separated by a separator.
+		// \p{L} matches letters outside the ASCII range.
+		$regex = '/^(-?[\d\p{L}]+)\s*?[\/\-\s.,]\s*(-?[\d\p{L}]+)$/u';
+		if ( !preg_match( $regex, $newValue, $matches ) ) {
+			throw new ParseException( 'Failed to parse year and month', $originalValue, self::FORMAT_NAME );
+		}
+		return array_splice( $matches, 1 );
 	}
 
 	/**

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -22,7 +22,7 @@ class TimeValueCalculatorTest extends TestCase {
 	 */
 	private $calculator;
 
-	protected function setUp() : void {
+	protected function setUp(): void {
 		$this->calculator = new TimeValueCalculator();
 	}
 

--- a/tests/ValueParsers/PhpDateTimeParserTest.php
+++ b/tests/ValueParsers/PhpDateTimeParserTest.php
@@ -48,7 +48,7 @@ class PhpDateTimeParserTest extends ValueParserTestCase {
 			->method( 'parse' )
 			->with( $this->isType( 'string' ) )
 			->will( $this->returnCallback(
-				function ( $value ) {
+				static function ( $value ) {
 					$sign = '+';
 					// Tiny parser that supports a single negative sign only
 					if ( $value[0] === '-' ) {

--- a/tests/ValueParsers/YearTimeParserTest.php
+++ b/tests/ValueParsers/YearTimeParserTest.php
@@ -42,7 +42,7 @@ class YearTimeParserTest extends ValueParserTestCase {
 			->method( 'parse' )
 			->with( $this->isType( 'string' ) )
 			->will( $this->returnCallback(
-				function ( $value ) {
+				static function ( $value ) {
 					$sign = '+';
 					// Tiny parser that supports a single negative sign only
 					if ( $value[0] === '-' ) {


### PR DESCRIPTION
On top of some minor changes, this splits a new `splitByYearMonth` from `YearMonthTimeParser::stringParse` (in order to make `mediawiki/mediawiki-codesniffer` `^39` happy).