### PR TITLE
Relax data-values/data-values version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ employees for the [Wikidata project](https://wikidata.org/).
 
 ## Release notes
 
+### 1.1.1 (2022-10-21)
+
+* Allow installation together with DataValues 3.1
+
 ### 1.1.0 (2022-10-21)
 
 * Improved compatibility with PHP 8.1;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require": {
 		"php": ">=7.2.0",
-		"data-values/data-values": "3.0.0|~2.0|~1.0|~0.1",
+		"data-values/data-values": "~3.0|~2.0|~1.0|~0.1",
 		"data-values/interfaces": "1.0.0|~0.2.0",
 		"data-values/common": "1.0.0|~0.4.0|~0.3.0"
 	},


### PR DESCRIPTION
There’s no reason to require *exactly* version 3.0.0, we want people to use 3.1.0.