### PR TITLE
Relax additional version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ employees for the [Wikidata project](https://wikidata.org/).
 
 ## Release notes
 
+### 1.1.2 (2022-10-24)
+
+* Allow installation together with data-values/common 1.1.0 and data-values/interfaces 1.x
+
 ### 1.1.1 (2022-10-21)
 
 * Allow installation together with DataValues 3.1

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
 	"require": {
 		"php": ">=7.2.0",
 		"data-values/data-values": "~3.0|~2.0|~1.0|~0.1",
-		"data-values/interfaces": "1.0.0|~0.2.0",
-		"data-values/common": "1.0.0|~0.4.0|~0.3.0"
+		"data-values/interfaces": "~1.0|~0.2.0",
+		"data-values/common": "~1.0|~0.4.0|~0.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~8.5",


### PR DESCRIPTION
Very similar to 110a68647f (#165), we want newer versions of data-values/common and data-values/interfaces to be installable too. (Interfaces doesn’t have a newer version yet, but any 1.x version should be compatible according to semver.)