### PR TITLE
Don’t unlocalize month names without letters

### DIFF
--- a/src/ValueParsers/MonthNameUnlocalizer.php
+++ b/src/ValueParsers/MonthNameUnlocalizer.php
@@ -46,6 +46,10 @@ class MonthNameUnlocalizer {
 			if ( !is_string( $search ) ) {
 				continue;
 			}
+			if ( !preg_match( '/\\p{L}/', $search ) ) {
+				// no letters in here (e.g. "1." for "jan"), do not use (might match day rather than month: T325988)
+				continue;
+			}
 
 			$unlocalized = str_replace( $search, $replace, $date, $count );
 

--- a/tests/ValueParsers/MonthNameUnlocalizerTest.php
+++ b/tests/ValueParsers/MonthNameUnlocalizerTest.php
@@ -79,6 +79,10 @@ class MonthNameUnlocalizerTest extends TestCase {
 			array( '2000', '2000', array(
 				'2' => 'February',
 			) ),
+			// And others (e.g. cs) just repeat the number of the month with punctuation
+			array( '5. 4. 1891', '5. 4. 1891', array(
+				'5.' => 'May',
+			) ),
 		);
 	}
 


### PR DESCRIPTION
The case of purely-numeric month names (ko) is already handled, because PHP implicitly turns such array keys into integers, and then they fail the existing `is_string()` check. But `MonthNameUnlocalizer` would still unlocalize month names that only consisted of numbers and punctuation (cs), which isn’t right either; add another check to prevent that.

Bug: [T325988](https://phabricator.wikimedia.org/T325988)