### PR TITLE
Upgrade mediawiki-codesniffer to latest version (45.0.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=7.2.0",
+		"php": ">=7.4.0",
 		"data-values/data-values": "~3.0|~2.0|~1.0|~0.1",
 		"data-values/interfaces": "~1.0|~0.2.0",
 		"data-values/common": "~1.0|~0.4.0|~0.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~8.5",
-		"mediawiki/mediawiki-codesniffer": "^39"
+		"mediawiki/mediawiki-codesniffer": "^45"
 	},
 	"autoload": {
 		"psr-0": {
@@ -54,5 +54,10 @@
 			"phpcs -p -s",
 			"phpunit"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -238,7 +238,7 @@ class TimeValue extends DataValueObject {
 			throw new IllegalValueException( '$timestamp must resemble ISO 8601, given ' . $timestamp );
 		}
 
-		list( , $sign, $year, $month, $day, $hour, $minute, $second ) = $matches;
+		[ , $sign, $year, $month, $day, $hour, $minute, $second ] = $matches;
 
 		if ( $month > 12 ) {
 			throw new IllegalValueException( 'Month out of allowed bounds' );
@@ -373,7 +373,7 @@ class TimeValue extends DataValueObject {
 	}
 
 	public function __unserialize( array $data ): void {
-		list( $timestamp, $timezone, $before, $after, $precision, $calendarModel ) = $data;
+		[ $timestamp, $timezone, $before, $after, $precision, $calendarModel ] = $data;
 		$this->__construct( $timestamp, $timezone, $before, $after, $precision, $calendarModel );
 	}
 

--- a/src/DataValues/TimeValueCalculator.php
+++ b/src/DataValues/TimeValueCalculator.php
@@ -47,7 +47,7 @@ class TimeValueCalculator {
 		) {
 			throw new InvalidArgumentException( "Failed to parse time value $time." );
 		}
-		list( , $fullYear, $month, $day, $hour, $minute, $second ) = $matches;
+		[ , $fullYear, $month, $day, $hour, $minute, $second ] = $matches;
 
 		// We use mktime only for the month, day and time calculation. Set the year to the smallest
 		// possible in the 1970-2038 range to be safe, even if it's 1901-2038 since PHP 5.1.0.
@@ -78,10 +78,10 @@ class TimeValueCalculator {
 	 */
 	public function isLeapYear( $year ) {
 		$year = $year < 0 ? ceil( $year ) + 1 : floor( $year );
-		$isMultipleOf4   = fmod( $year,   4 ) === 0.0;
+		$isMultipleOf4   = fmod( $year, 4 ) === 0.0;
 		$isMultipleOf100 = fmod( $year, 100 ) === 0.0;
 		$isMultipleOf400 = fmod( $year, 400 ) === 0.0;
-		return $isMultipleOf4 && !$isMultipleOf100 || $isMultipleOf400;
+		return ( $isMultipleOf4 && !$isMultipleOf100 ) || $isMultipleOf400;
 	}
 
 	/**

--- a/src/ValueFormatters/TimeFormatter.php
+++ b/src/ValueFormatters/TimeFormatter.php
@@ -48,7 +48,7 @@ class TimeFormatter implements ValueFormatter {
 	 *
 	 * @param FormatterOptions|null $options
 	 */
-	public function __construct( FormatterOptions $options = null ) {
+	public function __construct( ?FormatterOptions $options = null ) {
 		$this->options = $options ?: new FormatterOptions();
 
 		$this->options->defaultOption( self::OPT_CALENDARNAMES, array() );

--- a/src/ValueParsers/CalendarModelParser.php
+++ b/src/ValueParsers/CalendarModelParser.php
@@ -38,7 +38,7 @@ class CalendarModelParser extends StringValueParser {
 	/**
 	 * @param ParserOptions|null $options
 	 */
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		parent::__construct( $options );
 
 		$this->defaultOption( self::OPT_CALENDAR_MODEL_URIS, array() );

--- a/src/ValueParsers/IsoTimestampParser.php
+++ b/src/ValueParsers/IsoTimestampParser.php
@@ -58,8 +58,8 @@ class IsoTimestampParser extends StringValueParser {
 	 * @param ParserOptions|null $options
 	 */
 	public function __construct(
-		CalendarModelParser $calendarModelParser = null,
-		ParserOptions $options = null
+		?CalendarModelParser $calendarModelParser = null,
+		?ParserOptions $options = null
 	) {
 		parent::__construct( $options );
 
@@ -114,7 +114,7 @@ class IsoTimestampParser extends StringValueParser {
 			throw new ParseException( 'Malformed time' );
 		}
 
-		list( , $sign, $year, $month, $day, $hour, $minute, $second, $calendarModel ) = $matches;
+		[ , $sign, $year, $month, $day, $hour, $minute, $second, $calendarModel ] = $matches;
 
 		if ( $sign === ''
 			&& strlen( $year ) < 3
@@ -228,7 +228,7 @@ class IsoTimestampParser extends StringValueParser {
 	 * @return string URI
 	 */
 	private function getCalendarModel( array $timeParts ) {
-		list( $sign, $unsignedYear, , , , , , $calendarModel ) = $timeParts;
+		[ $sign, $unsignedYear, , , , , , $calendarModel ] = $timeParts;
 
 		if ( !empty( $calendarModel ) ) {
 			return $this->calendarModelParser->parse( $calendarModel );

--- a/src/ValueParsers/PhpDateTimeParser.php
+++ b/src/ValueParsers/PhpDateTimeParser.php
@@ -77,7 +77,7 @@ class PhpDateTimeParser extends StringValueParser {
 		$rawValue = $value;
 
 		try {
-			list( $sign, $value ) = $this->eraParser->parse( $value );
+			[ $sign, $value ] = $this->eraParser->parse( $value );
 
 			$value = trim( $value );
 			$value = $this->monthNameUnlocalizer->unlocalize( $value );
@@ -167,10 +167,10 @@ class PhpDateTimeParser extends StringValueParser {
 		// documentation of the extraction heuristics up to date!
 		$patterns = array(
 			// Check if the string contains a number longer than 2 digits or bigger than 59.
-			'/(?<!\d)('           // cannot be prepended by a digit
-				. '\d{3,}|'       // any number longer than 2 digits, or
-				. '[6-9]\d'       // any number bigger than 59
-				. ')(?!\d)/',     // cannot be followed by a digit
+			'/(?<!\d)('       // cannot be prepended by a digit
+				. '\d{3,}|'   // any number longer than 2 digits, or
+				. '[6-9]\d'   // any number bigger than 59
+				. ')(?!\d)/', // cannot be followed by a digit
 
 			// Check if the first number in the string is bigger than 31.
 			'/^\D*(3[2-9]|[4-9]\d)/',
@@ -178,8 +178,8 @@ class PhpDateTimeParser extends StringValueParser {
 			// Check if the string starts with three space-separated parts or three numbers.
 			'/^(?:'
 				. '\S+\s+\S+\s+|' // e.g. "July<SPACE>4th<SPACE>", or
-				. '\d+\D+\d+\D+'  // e.g. "4.7."
-				. ')(\d+)/',      // followed by a number
+				. '\d+\D+\d+\D+' // e.g. "4.7."
+				. ')(\d+)/', // followed by a number
 
 			// Check if the string ends with a number.
 			'/(\d+)\D*$/',

--- a/src/ValueParsers/YearMonthDayTimeParser.php
+++ b/src/ValueParsers/YearMonthDayTimeParser.php
@@ -32,7 +32,7 @@ class YearMonthDayTimeParser extends StringValueParser {
 	 * returns an array with the detected sign character and the remaining value.
 	 * @param ParserOptions|null $options
 	 */
-	public function __construct( ValueParser $eraParser = null, ParserOptions $options = null ) {
+	public function __construct( ?ValueParser $eraParser = null, ?ParserOptions $options = null ) {
 		parent::__construct( $options );
 
 		$this->eraParser = $eraParser ?: new EraParser();
@@ -47,8 +47,8 @@ class YearMonthDayTimeParser extends StringValueParser {
 	 */
 	protected function stringParse( $value ) {
 		try {
-			list( $sign, $preparsedValue ) = $this->eraParser->parse( $value );
-			list( $signedYear, $month, $day ) = $this->parseYearMonthDay( $preparsedValue );
+			[ $sign, $preparsedValue ] = $this->eraParser->parse( $value );
+			[ $signedYear, $month, $day ] = $this->parseYearMonthDay( $preparsedValue );
 
 			if ( substr( $signedYear, 0, 1 ) !== '-' ) {
 				$signedYear = $sign . $signedYear;
@@ -76,9 +76,9 @@ class YearMonthDayTimeParser extends StringValueParser {
 		// A 32 in the first spot cannot be confused with anything.
 		if ( $matches[1] < 1 || $matches[1] > 31 ) {
 			if ( $matches[3] > 12 || $matches[2] == $matches[3] ) {
-				list( , $signedYear, $month, $day ) = $matches;
+				[ , $signedYear, $month, $day ] = $matches;
 			} elseif ( $matches[2] > 12 ) {
-				list( , $signedYear, $day, $month ) = $matches;
+				[ , $signedYear, $day, $month ] = $matches;
 			} else {
 				throw new ParseException( 'Cannot distinguish YDM and YMD' );
 			}
@@ -88,9 +88,9 @@ class YearMonthDayTimeParser extends StringValueParser {
 			|| ( abs( $matches[1] ) > 24 && $matches[3] > 31 )
 		) {
 			if ( $matches[1] > 12 || $matches[1] == $matches[2] ) {
-				list( , $day, $month, $signedYear ) = $matches;
+				[ , $day, $month, $signedYear ] = $matches;
 			} elseif ( $matches[2] > 12 ) {
-				list( , $month, $day, $signedYear ) = $matches;
+				[ , $month, $day, $signedYear ] = $matches;
 			} else {
 				throw new ParseException( 'Cannot distinguish DMY and MDY' );
 			}

--- a/src/ValueParsers/YearMonthTimeParser.php
+++ b/src/ValueParsers/YearMonthTimeParser.php
@@ -44,8 +44,8 @@ class YearMonthTimeParser extends StringValueParser {
 	 */
 	public function __construct(
 		MonthNameProvider $monthNameProvider,
-		ParserOptions $options = null,
-		EraParser $eraParser = null
+		?ParserOptions $options = null,
+		?EraParser $eraParser = null
 	) {
 		parent::__construct( $options );
 
@@ -64,8 +64,8 @@ class YearMonthTimeParser extends StringValueParser {
 	 * @return TimeValue
 	 */
 	protected function stringParse( $value ) {
-		list( $newValue, $sign ) = $this->splitBySignAndEra( $value );
-		list( $a, $b ) = $this->splitByYearMonth( $value, $newValue );
+		[ $newValue, $sign ] = $this->splitBySignAndEra( $value );
+		[ $a, $b ] = $this->splitByYearMonth( $value, $newValue );
 
 		// non-empty sign indicates the era (e.g. "BCE") was specified
 		// don't accept a negative number as the year
@@ -131,7 +131,7 @@ class YearMonthTimeParser extends StringValueParser {
 			$newValue = $trimmedValue;
 			$sign = '';
 		} else {
-			list( $sign, $newValue ) = $this->eraParser->parse( $trimmedValue );
+			[ $sign, $newValue ] = $this->eraParser->parse( $trimmedValue );
 			if ( $newValue === $trimmedValue ) {
 				// EraParser defaults to "+" but we need to indicate "unspecified era"
 				$sign = '';

--- a/src/ValueParsers/YearTimeParser.php
+++ b/src/ValueParsers/YearTimeParser.php
@@ -47,7 +47,7 @@ class YearTimeParser extends StringValueParser {
 	 * @param ValueParser|null $eraParser
 	 * @param ParserOptions|null $options
 	 */
-	public function __construct( ValueParser $eraParser = null, ParserOptions $options = null ) {
+	public function __construct( ?ValueParser $eraParser = null, ?ParserOptions $options = null ) {
 		parent::__construct( $options );
 
 		$this->defaultOption(
@@ -68,7 +68,7 @@ class YearTimeParser extends StringValueParser {
 	 * @return TimeValue
 	 */
 	protected function stringParse( $value ) {
-		list( $sign, $year ) = $this->eraParser->parse( $value );
+		[ $sign, $year ] = $this->eraParser->parse( $value );
 		$year = trim( $year );
 
 		// Negative dates usually don't have a month, assume non-digits are thousands separators

--- a/tests/DataValues/TimeValueCalculatorTest.php
+++ b/tests/DataValues/TimeValueCalculatorTest.php
@@ -39,16 +39,16 @@ class TimeValueCalculatorTest extends TestCase {
 
 		$timeValue->expects( $this->any() )
 			->method( 'getTime' )
-			->will( $this->returnValue( $time ) );
+			->willReturn( $time );
 		$timeValue->expects( $this->any() )
 			->method( 'getTimezone' )
-			->will( $this->returnValue( $timezone ) );
+			->willReturn( $timezone );
 		$timeValue->expects( $this->any() )
 			->method( 'getPrecision' )
-			->will( $this->returnValue( TimeValue::PRECISION_DAY ) );
+			->willReturn( TimeValue::PRECISION_DAY );
 		$timeValue->expects( $this->any() )
 			->method( 'getCalendarModel' )
-			->will( $this->returnValue( 'Stardate' ) );
+			->willReturn( 'Stardate' );
 
 		return $timeValue;
 	}

--- a/tests/ValueFormatters/TimeFormatterTest.php
+++ b/tests/ValueFormatters/TimeFormatterTest.php
@@ -27,7 +27,7 @@ class TimeFormatterTest extends TestCase {
 	 *
 	 * @return TimeFormatter
 	 */
-	protected function getInstance( FormatterOptions $options = null ) {
+	protected function getInstance( ?FormatterOptions $options = null ) {
 		return new TimeFormatter( $options );
 	}
 
@@ -109,8 +109,8 @@ class TimeFormatterTest extends TestCase {
 	public function testValidFormat(
 		$value,
 		$expected,
-		FormatterOptions $options = null,
-		ValueFormatter $formatter = null
+		?FormatterOptions $options = null,
+		?ValueFormatter $formatter = null
 	) {
 		if ( $formatter === null ) {
 			$formatter = $this->getInstance( $options );

--- a/tests/ValueParsers/PhpDateTimeParserTest.php
+++ b/tests/ValueParsers/PhpDateTimeParserTest.php
@@ -47,7 +47,7 @@ class PhpDateTimeParserTest extends ValueParserTestCase {
 		$mock->expects( $this->any() )
 			->method( 'parse' )
 			->with( $this->isType( 'string' ) )
-			->will( $this->returnCallback(
+			->willReturnCallback(
 				static function ( $value ) {
 					$sign = '+';
 					// Tiny parser that supports a single negative sign only
@@ -57,7 +57,7 @@ class PhpDateTimeParserTest extends ValueParserTestCase {
 					}
 					return array( $sign, $value );
 				}
-			) );
+			);
 
 		return $mock;
 	}

--- a/tests/ValueParsers/ValueParserTestCase.php
+++ b/tests/ValueParsers/ValueParserTestCase.php
@@ -59,7 +59,7 @@ abstract class ValueParserTestCase extends TestCase {
 	 * @param mixed $expected
 	 * @param ValueParser|null $parser
 	 */
-	public function testParseWithValidInputs( $value, $expected, ValueParser $parser = null ) {
+	public function testParseWithValidInputs( $value, $expected, ?ValueParser $parser = null ) {
 		if ( $parser === null ) {
 			$parser = $this->getInstance();
 		}
@@ -94,7 +94,7 @@ abstract class ValueParserTestCase extends TestCase {
 	 * @param mixed $value
 	 * @param ValueParser|null $parser
 	 */
-	public function testParseWithInvalidInputs( $value, ValueParser $parser = null ) {
+	public function testParseWithInvalidInputs( $value, ?ValueParser $parser = null ) {
 		if ( $parser === null ) {
 			$parser = $this->getInstance();
 		}

--- a/tests/ValueParsers/YearMonthTimeParserTest.php
+++ b/tests/ValueParsers/YearMonthTimeParserTest.php
@@ -32,14 +32,14 @@ class YearMonthTimeParserTest extends ValueParserTestCase {
 		$monthNameProvider->expects( $this->once() )
 			->method( 'getMonthNumbers' )
 			->with( 'en' )
-			->will( $this->returnValue( array(
+			->willReturn( array(
 				'January' => 1,
 				'Jan' => 1,
 				// to test Unicode (it's Czech)
 				'Březen' => 3,
 				'April' => 4,
 				'June' => 6,
-			) ) );
+			) );
 
 		return new YearMonthTimeParser( $monthNameProvider );
 	}

--- a/tests/ValueParsers/YearTimeParserTest.php
+++ b/tests/ValueParsers/YearTimeParserTest.php
@@ -41,7 +41,7 @@ class YearTimeParserTest extends ValueParserTestCase {
 		$mock->expects( $this->any() )
 			->method( 'parse' )
 			->with( $this->isType( 'string' ) )
-			->will( $this->returnCallback(
+			->willReturnCallback(
 				static function ( $value ) {
 					$sign = '+';
 					// Tiny parser that supports a single negative sign only
@@ -51,7 +51,7 @@ class YearTimeParserTest extends ValueParserTestCase {
 					}
 					return array( $sign, $value );
 				}
-			) );
+			);
 		return $mock;
 	}
 


### PR DESCRIPTION
This repository is currently using version 34 of the Mediawiki coding style phpcs rules. It should be upgraded to the latest version.

Besides being simply different, the newer versions of the rules introduce, for example,
MediaWiki.Usage.NullableType.ExplicitNullableTypes, which enforces compliance with coming deprecation rules in PHP 8.4 concerning nullable types. If the code does not remove the soon-to-be-deprecated form of nullable type declarations, the library will no longer be usable in Mediawiki for PHP 8.4 deployments.

Bug: T379481